### PR TITLE
Upgrade to spdx-exceptions@1.0.4

### DIFF
--- a/generate-parser.js
+++ b/generate-parser.js
@@ -17,9 +17,6 @@ var handleLicensesAndExceptions = function() {
   var ids = require('spdx-license-ids');
   var exceptions = require('spdx-exceptions');
 
-  // Work around the fact that SPDX exception list has trailing whitespace.
-  exceptions = exceptions.map(function(s) { return s.trim(); });
-
   // Sort tokens longest-first (both license ids and exception strings)
   var tokens = ids.concat(exceptions);
   tokens.sort(function(a, b) { return b.length - a.length; });

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "author": "Kyle E. Mitchell <kyle@kemitchell.com> (http://kemitchell.com)",
   "dependencies": {
-    "spdx-exceptions": "^1.0.0",
+    "spdx-exceptions": "^1.0.4",
     "spdx-license-ids": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Many thanks for kemitchell/spdx-exceptions.json#2! Since spdx-exceptions@1.0.4 is whitespace clean, we can take the trimming code out of your PR to spdx-expression-parse.
